### PR TITLE
fix: pytorch to deeppavlov

### DIFF
--- a/demo/docs/index.rst
+++ b/demo/docs/index.rst
@@ -17,3 +17,10 @@ Demo Versioned Module
     long
     examples/examples_dir/index
     headers
+
+Indices and tables
+------------------
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/demo/docs/index.rst
+++ b/demo/docs/index.rst
@@ -17,10 +17,3 @@ Demo Versioned Module
     long
     examples/examples_dir/index
     headers
-
-Indices and tables
-------------------
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`

--- a/templates/footer.jinja
+++ b/templates/footer.jinja
@@ -51,7 +51,7 @@
         {%- if show_sphinx %}
             {% trans %}
                 <div>
-                    Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/pytorch/pytorch_sphinx_theme">theme</a> provided by <a href="https://pytorch.org/">PyTorch</a>.
+                    Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/deeppavlov/dff_sphinx_theme">theme</a> provided by <a href="https://deeppavlov.ai">DeepPavlov</a>.
                 </div>
             {% endtrans %}
         {%- endif %}


### PR DESCRIPTION
This PR fix PyTorch to DeepPavlov at the bottom of the page.